### PR TITLE
Updated graceful-fs to version 4.2.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "cheerio": "^0.19.0",
     "colors": "^1.1.0",
     "css": "^2.2.0",
-    "graceful-fs": "^3.0.6",
+    "graceful-fs": "^4.2.6",
     "juice": "^1.0.0",
     "lodash": "^3.5.0",
     "mkdirp": "^0.5.0",


### PR DESCRIPTION
Updates graceful-fs to the latest version, to avoid `“ReferenceError: primordials is not defined"` errors when used in conjunction with more recent versions of Node and Gulp.